### PR TITLE
add a 'center-master' flag for #32

### DIFF
--- a/inc/cfg.h
+++ b/inc/cfg.h
@@ -41,6 +41,8 @@
 
 #define BORDER_COLOR_UNFOCUSED_DEFAULT "0x586e75"
 
+#define FIXED_MASTER_WIDE_DEFAULT false
+
 // never null
 extern const struct Cfg * const cfg;
 
@@ -61,6 +63,7 @@ struct Cfg {
 	char border_color_focused[11];
 	char border_color_focused_monocle[11];
 	char border_color_unfocused[11];
+	bool fixed_master_wide;
 };
 
 // returns false if not valid
@@ -82,5 +85,7 @@ bool cfg_set_border_width_monocle(const char *s);
 bool cfg_set_border_color_focused(const char *s);
 bool cfg_set_border_color_focused_monocle(const char *s);
 bool cfg_set_border_color_unfocused(const char *s);
+
+void cfg_set_fixed_master_wide(bool fixed_master_wide);
 
 #endif // CFG_H

--- a/inc/cfg.h
+++ b/inc/cfg.h
@@ -41,7 +41,7 @@
 
 #define BORDER_COLOR_UNFOCUSED_DEFAULT "0x586e75"
 
-#define FIXED_MASTER_WIDE_DEFAULT false
+#define CENTER_MASTER_DEFAULT false
 
 // never null
 extern const struct Cfg * const cfg;
@@ -63,7 +63,7 @@ struct Cfg {
 	char border_color_focused[11];
 	char border_color_focused_monocle[11];
 	char border_color_unfocused[11];
-	bool fixed_master_wide;
+	bool center_master;
 };
 
 // returns false if not valid
@@ -86,6 +86,6 @@ bool cfg_set_border_color_focused(const char *s);
 bool cfg_set_border_color_focused_monocle(const char *s);
 bool cfg_set_border_color_unfocused(const char *s);
 
-void cfg_set_fixed_master_wide(bool fixed_master_wide);
+void cfg_set_center_master(bool fixed_master_wide);
 
 #endif // CFG_H

--- a/inc/tag.h
+++ b/inc/tag.h
@@ -17,7 +17,7 @@ struct Tag {
 	uint32_t count_wide_left;
 	double ratio_wide;
 	bool smart_gaps;
-	bool fixed_master_wide;  // Whether to maintain master ratio in wide layout when no side views
+	bool center_master;  // Whether to maintain master ratio in wide layout when no side views
 	uint32_t inner_gaps;
 	uint32_t outer_gaps;
 };

--- a/inc/tag.h
+++ b/inc/tag.h
@@ -17,6 +17,7 @@ struct Tag {
 	uint32_t count_wide_left;
 	double ratio_wide;
 	bool smart_gaps;
+	bool fixed_master_wide;  // Whether to maintain master ratio in wide layout when no side views
 	uint32_t inner_gaps;
 	uint32_t outer_gaps;
 };

--- a/inc/tag.h
+++ b/inc/tag.h
@@ -17,7 +17,7 @@ struct Tag {
 	uint32_t count_wide_left;
 	double ratio_wide;
 	bool smart_gaps;
-	bool center_master;  // Whether to maintain master ratio in wide layout when no side views
+	bool center_master;
 	uint32_t inner_gaps;
 	uint32_t outer_gaps;
 };

--- a/src/args.c
+++ b/src/args.c
@@ -34,7 +34,7 @@ static struct option cli_long_options[] = {
 	{ "help-defaults",                no_argument,       0, 0, }, // 18
 	{ "log-threshold",                required_argument, 0, 0, }, // 19
 	{ "version",                      no_argument,       0, 0, }, // 20
-	{ "fixed-master-wide",            no_argument,       0, 0, }, // 21
+	{ "center-master",                no_argument,       0, 0, }, // 21
 	{ 0,                              0,                 0, 0, }
 };
 
@@ -181,7 +181,7 @@ void args_cli(int argc, char **argv) {
 				exit(EXIT_SUCCESS);
 				return;
 			case 21:
-				cfg_set_fixed_master_wide(true);
+				cfg_set_center_master(true);
 				break;
 			default:
 				fprintf(stderr, "\n");
@@ -207,7 +207,7 @@ void args_cli(int argc, char **argv) {
 	log_i("--border-color-focused-monocle %s",  cfg->border_color_focused_monocle);
 	log_i("--border-color-unfocused       %s",  cfg->border_color_unfocused);
 	log_i("--log-threshold                %s",  log_threshold_name(log_get_threshold()));
-	log_i("%s",  cfg->fixed_master_wide ? "--fixed-master-wide" : "");
+	log_i("--%scenter-master",                  cfg->center_master ? "" : "no-");
 }
 
 static struct option cmd_long_options[] = {

--- a/src/args.c
+++ b/src/args.c
@@ -34,6 +34,7 @@ static struct option cli_long_options[] = {
 	{ "help-defaults",                no_argument,       0, 0, }, // 18
 	{ "log-threshold",                required_argument, 0, 0, }, // 19
 	{ "version",                      no_argument,       0, 0, }, // 20
+	{ "fixed-master-wide",            no_argument,       0, 0, }, // 21
 	{ 0,                              0,                 0, 0, }
 };
 
@@ -179,6 +180,9 @@ void args_cli(int argc, char **argv) {
 				fprintf(stdout, "wideriver version %s\n", VERSION);
 				exit(EXIT_SUCCESS);
 				return;
+			case 21:
+				cfg_set_fixed_master_wide(true);
+				break;
 			default:
 				fprintf(stderr, "\n");
 				usage(EXIT_FAILURE);
@@ -203,6 +207,7 @@ void args_cli(int argc, char **argv) {
 	log_i("--border-color-focused-monocle %s",  cfg->border_color_focused_monocle);
 	log_i("--border-color-unfocused       %s",  cfg->border_color_unfocused);
 	log_i("--log-threshold                %s",  log_threshold_name(log_get_threshold()));
+	log_i("%s",  cfg->fixed_master_wide ? "--fixed-master-wide" : "");
 }
 
 static struct option cmd_long_options[] = {

--- a/src/arrange.c
+++ b/src/arrange.c
@@ -132,10 +132,14 @@ void arrange_master_stack(const struct Demand* const demand,
 		return;
 	}
 	if (num_stack == 0) {
-		master->width = demand->usable_width - 2 * outer_gap;
-		master->height = demand->usable_height - 2 * outer_gap;
-		master->x = outer_gap;
-		master->y = outer_gap;
+		if (tag->center_master) {
+			center_master_view(demand, tag, master, tag->ratio_master);
+		} else {
+			master->width = demand->usable_width - 2 * outer_gap;
+			master->height = demand->usable_height - 2 * outer_gap;
+			master->x = outer_gap;
+			master->y = outer_gap;
+		}
 		return;
 	}
 
@@ -228,7 +232,7 @@ void arrange_wide(const struct Demand *demand,
 	if (demand->view_count == 1 && tag->smart_gaps) {
 		inner_gap = 0;
 		outer_gap = 0;
-	} 
+	}
 
 	// 000
 	if (num_master == 0 && num_before == 0 && num_after == 0) {
@@ -252,7 +256,7 @@ void arrange_wide(const struct Demand *demand,
 	int right_x = center_x + center_w + inner_gap;
 
 	// 010 - only master
-	if (num_master && !num_before && !num_after) {
+	if (!num_before && num_master && !num_after) {
 		if (tag->center_master) {
 		  center_master_view(demand, tag, master, tag->ratio_wide);
 		} else {
@@ -288,7 +292,7 @@ void arrange_wide(const struct Demand *demand,
 	    return;
 	}
   
-	// 011 
+	// 011
 	if (!num_before && num_master && num_after) {
 		if (tag->center_master) {
 			master->width = center_w;

--- a/src/arrange.c
+++ b/src/arrange.c
@@ -20,6 +20,8 @@ static inline void center_master_view(const struct Demand *d,
 
 	int w = (usable_w * ratio) + 0.5f;
 	int h = (usable_h * ratio) + 0.5f;
+	int x = outer_gap;
+	int y = outer_gap;
 
 	switch (tag->layout_cur) {
 		// we want full-height here
@@ -27,21 +29,24 @@ static inline void center_master_view(const struct Demand *d,
 		case RIGHT:
 		case WIDE:
 			h = usable_h;
+			x = (usable_w - w) / 2;
 			break;
 
 		// we want full-width but not height
 		case TOP:
 		case BOTTOM:
 			w = usable_w;
-			box->y = (usable_h - box->height) / 2;
+			box->x = x;
+			box->y = ((usable_h - h ) / 2.0f) + 0.5f;
 			break;
 		case MONOCLE:
-			// noop, but leave ratios on w,h
+			// noop
 			break;
 	}
+	box->x = x;
+	box->y = y;
 	box->width = w;
 	box->height = h;
-	box->x = (usable_w - box->width) / 2;
 }
 
 

--- a/src/arrange.c
+++ b/src/arrange.c
@@ -201,10 +201,17 @@ void arrange_wide(const struct Demand *demand,
 
 	// 010
 	if (!num_before && num_master && !num_after) {
-		master->width = demand->usable_width - 2 * outer_gap;
-		master->height = demand->usable_height - 2 * outer_gap;
-		master->x = outer_gap;
-		master->y = outer_gap;
+		if (tag->fixed_master_wide) {
+			master->width = (demand->usable_width - 2 * (outer_gap + inner_gap)) * tag->ratio_wide + 0.5f;
+			master->height = demand->usable_height - 2 * outer_gap;
+			master->x = (demand->usable_width - master->width) / 2.0f + 0.5f;
+			master->y = outer_gap;
+		}else {
+			master->width = demand->usable_width - 2 * outer_gap;
+			master->height = demand->usable_height - 2 * outer_gap;
+			master->x = outer_gap;
+			master->y = outer_gap;
+		}
 		return;
 	}
 
@@ -242,10 +249,17 @@ void arrange_wide(const struct Demand *demand,
 
 	// 011
 	if (!num_before && num_master && num_after) {
-		master->width = (demand->usable_width - 2 * outer_gap - inner_gap) * (tag->ratio_wide + (1.0f - tag->ratio_wide) / 2.0f) + 0.5f;
-		master->height = demand->usable_height - 2 * outer_gap;
-		master->x = outer_gap;
-		master->y = outer_gap;
+		if (tag->fixed_master_wide) {
+			master->width = (demand->usable_width - 2 * (outer_gap + inner_gap)) * tag->ratio_wide + 0.5f;
+			master->height = demand->usable_height - 2 * outer_gap;
+			master->x = (demand->usable_width - master->width) / 2.0f + 0.5f;
+			master->y = outer_gap;
+		} else {
+			master->width = (demand->usable_width - 2 * outer_gap - inner_gap) * (tag->ratio_wide + (1.0f - tag->ratio_wide) / 2.0f) + 0.5f;
+			master->height = demand->usable_height - 2 * outer_gap;
+			master->x = outer_gap;
+			master->y = outer_gap;
+		}
 
 		after->width = demand->usable_width - master->width - 2 * outer_gap - inner_gap;
 		after->height = demand->usable_height - 2 * outer_gap;
@@ -256,10 +270,17 @@ void arrange_wide(const struct Demand *demand,
 
 	// 110
 	if (num_before && num_master && !num_after) {
-		master->width = (demand->usable_width - 2 * outer_gap - inner_gap) * (tag->ratio_wide + (1.0f - tag->ratio_wide) / 2.0f) + 0.5f;
-		master->height = demand->usable_height - 2 * outer_gap;
-		master->x = demand->usable_width - master->width - outer_gap;
-		master->y = outer_gap;
+		if (tag->fixed_master_wide) {
+			master->width = (demand->usable_width - 2 * (outer_gap + inner_gap)) * tag->ratio_wide + 0.5f;
+			master->height = demand->usable_height - 2 * outer_gap;
+			master->x = (demand->usable_width - master->width) / 2.0f + 0.5f;
+			master->y = outer_gap;
+		} else {
+			master->width = (demand->usable_width - 2 * outer_gap - inner_gap) * (tag->ratio_wide + (1.0f - tag->ratio_wide) / 2.0f) + 0.5f;
+			master->height = demand->usable_height - 2 * outer_gap;
+			master->x = demand->usable_width - master->width - outer_gap;
+			master->y = outer_gap;
+		}
 
 		before->width = master->x - outer_gap - inner_gap;
 		before->height = demand->usable_height - 2 * outer_gap;

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -24,6 +24,7 @@ struct Cfg c = {
 	.border_color_focused = BORDER_COLOR_FOCUSED_DEFAULT,
 	.border_color_focused_monocle = BORDER_COLOR_FOCUSED_MONOCLE_DEFAULT,
 	.border_color_unfocused = BORDER_COLOR_UNFOCUSED_DEFAULT,
+	.fixed_master_wide = FIXED_MASTER_WIDE_DEFAULT,
 };
 
 const struct Cfg * const cfg = &c;
@@ -212,4 +213,8 @@ bool cfg_set_border_color_unfocused(const char *s) {
 		return true;
 	}
 	return false;
+}
+
+void cfg_set_fixed_master_wide(bool fixed_master_wide) {
+	c.fixed_master_wide = fixed_master_wide;
 }

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -24,7 +24,7 @@ struct Cfg c = {
 	.border_color_focused = BORDER_COLOR_FOCUSED_DEFAULT,
 	.border_color_focused_monocle = BORDER_COLOR_FOCUSED_MONOCLE_DEFAULT,
 	.border_color_unfocused = BORDER_COLOR_UNFOCUSED_DEFAULT,
-	.fixed_master_wide = FIXED_MASTER_WIDE_DEFAULT,
+	.center_master = CENTER_MASTER_DEFAULT,
 };
 
 const struct Cfg * const cfg = &c;
@@ -215,6 +215,6 @@ bool cfg_set_border_color_unfocused(const char *s) {
 	return false;
 }
 
-void cfg_set_fixed_master_wide(bool fixed_master_wide) {
-	c.fixed_master_wide = fixed_master_wide;
+void cfg_set_center_master(bool center_master) {
+	c.center_master = center_master;
 }

--- a/src/layout.c
+++ b/src/layout.c
@@ -161,18 +161,11 @@ struct SList *layout(const struct Demand *demand, const struct Tag *tag) {
 			arrange_monocle(demand, tag, &views);
 			break;
 		case WIDE:
+			// master first
+			arrange_views(demand, EVEN, S, S, num_master, num_master, tag->inner_gaps, box_master, box_master, &views);
+
 			// left stack dwindle left up
 			arrange_views(demand, tag->stack, N, W, num_before, num_before, tag->inner_gaps, box_before, box_before, &views);
-
-			// reverse to push first view farthest away
-			struct SList *views_reversed = NULL;
-			for (int i = slist_length(views) - 1; i >= 0; i--)
-				slist_append(&views_reversed, slist_at(views, i));
-			slist_free(&views);
-			views = views_reversed;
-
-			// only one master
-			arrange_views(demand, EVEN, S, S, num_master, num_master, tag->inner_gaps, box_master, box_master, &views);
 
 			// right stack dwindle right down
 			arrange_views(demand, tag->stack, S, E, num_after, num_after, tag->inner_gaps, box_after, box_after, &views);

--- a/src/tag.c
+++ b/src/tag.c
@@ -22,6 +22,7 @@ struct Tag *tag_init(const uint32_t mask) {
 	tag->smart_gaps = cfg->smart_gaps;
 	tag->inner_gaps = cfg->inner_gaps;
 	tag->outer_gaps = cfg->outer_gaps;
+	tag->fixed_master_wide = cfg->fixed_master_wide;
 
 	tag->mask = mask;
 

--- a/src/tag.c
+++ b/src/tag.c
@@ -22,7 +22,7 @@ struct Tag *tag_init(const uint32_t mask) {
 	tag->smart_gaps = cfg->smart_gaps;
 	tag->inner_gaps = cfg->inner_gaps;
 	tag->outer_gaps = cfg->outer_gaps;
-	tag->fixed_master_wide = cfg->fixed_master_wide;
+	tag->center_master = cfg->center_master;
 
 	tag->mask = mask;
 

--- a/tst/tst-args_cli.c
+++ b/tst/tst-args_cli.c
@@ -32,7 +32,7 @@ int after_each(void **state) {
 }
 
 void args_parse_cli__valid(void **state) {
-	int argc = 34;
+	int argc = 35;
 	char *argv[] = { "dummy",
 		"--layout", "left",
 		"--layout-alt", "right",
@@ -51,6 +51,7 @@ void args_parse_cli__valid(void **state) {
 		"--border-color-focused-monocle", "0xDDEEFFA9",
 		"--border-color-unfocused", "0x001122",
 		"--log-threshold", "ERROR",
+		"--fixed-master-wide",
 	};
 
 	args_cli(argc, argv);
@@ -71,6 +72,7 @@ void args_parse_cli__valid(void **state) {
 	assert_str_equal(cfg->border_color_focused, "0xAABBCC");
 	assert_str_equal(cfg->border_color_focused_monocle, "0xDDEEFFA9");
 	assert_str_equal(cfg->border_color_unfocused, "0x001122");
+	assert_true(cfg->fixed_master_wide);
 
 	assert_log(INFO,
 			"--layout                       left\n"
@@ -90,6 +92,7 @@ void args_parse_cli__valid(void **state) {
 			"--border-color-focused-monocle 0xDDEEFFA9\n"
 			"--border-color-unfocused       0x001122\n"
 			"--log-threshold                error\n"
+			"--fixed-master-wide\n"
 			);
 }
 

--- a/tst/tst-args_cli.c
+++ b/tst/tst-args_cli.c
@@ -51,7 +51,7 @@ void args_parse_cli__valid(void **state) {
 		"--border-color-focused-monocle", "0xDDEEFFA9",
 		"--border-color-unfocused", "0x001122",
 		"--log-threshold", "ERROR",
-		"--fixed-master-wide",
+		"--center-master",
 	};
 
 	args_cli(argc, argv);
@@ -72,7 +72,7 @@ void args_parse_cli__valid(void **state) {
 	assert_str_equal(cfg->border_color_focused, "0xAABBCC");
 	assert_str_equal(cfg->border_color_focused_monocle, "0xDDEEFFA9");
 	assert_str_equal(cfg->border_color_unfocused, "0x001122");
-	assert_true(cfg->fixed_master_wide);
+	assert_true(cfg->center_master);
 
 	assert_log(INFO,
 			"--layout                       left\n"
@@ -92,7 +92,7 @@ void args_parse_cli__valid(void **state) {
 			"--border-color-focused-monocle 0xDDEEFFA9\n"
 			"--border-color-unfocused       0x001122\n"
 			"--log-threshold                error\n"
-			"--fixed-master-wide\n"
+			"--center-master\n"
 			);
 }
 

--- a/tst/tst-arrange.c
+++ b/tst/tst-arrange.c
@@ -64,10 +64,38 @@ void arrange_monocle__many_with_gaps(void **state) {
 	slist_free_vals(&stack, NULL);
 }
 
+void arrange_wide__single_view_fixed_master_wide(void **state) {
+	struct Demand demand = { .view_count = 1, .usable_width = 10, .usable_height = 5 };
+	struct Tag tag = { .layout_cur = WIDE, .ratio_wide = 0.5, .fixed_master_wide = true,
+		.inner_gaps = 0, .outer_gaps = 0 };
+
+	// With maintain_wide_ratio=true, the single view should be centered and maintain ratio
+	struct Box master = {0};
+	struct Box before = {0};
+	struct Box after = {0};
+	arrange_wide(&demand, &tag, 0, 1, 0, &before, &master, &after);
+	assert_box_equal(&master, 2, 0, 5, 5);
+}
+
+void arrange_wide__single_view_no_fixed_master_wide(void **state) {
+	struct Demand demand = { .view_count = 1, .usable_width = 10, .usable_height = 5 };
+	struct Tag tag = { .layout_cur = WIDE, .ratio_wide = 0.5, .fixed_master_wide = false,
+		.inner_gaps = 0, .outer_gaps = 0 };
+
+	// With maintain_wide_ratio=false, the single view should expand to full width
+	struct Box master = {0};
+	struct Box before = {0};
+	struct Box after = {0};
+	arrange_wide(&demand, &tag, 0, 1, 0, &before, &master, &after);
+	assert_box_equal(&master, 0, 0, 10, 5);
+}
+
 int main(void) {
 	const struct CMUnitTest tests[] = {
 		TEST(arrange_monocle__many),
 		TEST(arrange_monocle__many_with_gaps),
+		TEST(arrange_wide__single_view_fixed_master_wide),
+		TEST(arrange_wide__single_view_no_fixed_master_wide),
 	};
 
 	return RUN(tests);

--- a/tst/tst-arrange.c
+++ b/tst/tst-arrange.c
@@ -66,7 +66,7 @@ void arrange_monocle__many_with_gaps(void **state) {
 
 void arrange_wide__single_view_fixed_master_wide(void **state) {
 	struct Demand demand = { .view_count = 1, .usable_width = 10, .usable_height = 5 };
-	struct Tag tag = { .layout_cur = WIDE, .ratio_wide = 0.5, .fixed_master_wide = true,
+	struct Tag tag = { .layout_cur = WIDE, .ratio_wide = 0.5, .center_master = true,
 		.inner_gaps = 0, .outer_gaps = 0 };
 
 	// With maintain_wide_ratio=true, the single view should be centered and maintain ratio
@@ -79,7 +79,7 @@ void arrange_wide__single_view_fixed_master_wide(void **state) {
 
 void arrange_wide__single_view_no_fixed_master_wide(void **state) {
 	struct Demand demand = { .view_count = 1, .usable_width = 10, .usable_height = 5 };
-	struct Tag tag = { .layout_cur = WIDE, .ratio_wide = 0.5, .fixed_master_wide = false,
+	struct Tag tag = { .layout_cur = WIDE, .ratio_wide = 0.5, .center_master = false,
 		.inner_gaps = 0, .outer_gaps = 0 };
 
 	// With maintain_wide_ratio=false, the single view should expand to full width

--- a/tst/tst-arrange_mid.c
+++ b/tst/tst-arrange_mid.c
@@ -42,20 +42,7 @@ void arrange_wide__010(void **state) {
 	struct Box master, before, after;
 
 	struct Demand demand = { .usable_width = 13, .usable_height = 5, };
-	struct Tag tag = { .ratio_wide = 0.5, .fixed_master_wide = true };
-
-	arrange_wide(&demand, &tag, 0, 1, 0, &before, &master, &after);
-
-	assert_box_equal(&before, 0, 0, 0, 0);
-	assert_box_equal(&master, 3, 0, 6, 5);
-	assert_box_equal(&after, 0, 0, 0, 0);
-}
-
-void arrange_wide__010_no_fixed_master_wide(void **state) {
-	struct Box master, before, after;
-
-	struct Demand demand = { .usable_width = 13, .usable_height = 5, };
-	struct Tag tag = { .ratio_wide = 0.5, .fixed_master_wide = false };
+	struct Tag tag = { .ratio_wide = 0.5, .center_master = false };
 
 	arrange_wide(&demand, &tag, 0, 1, 0, &before, &master, &after);
 
@@ -64,35 +51,48 @@ void arrange_wide__010_no_fixed_master_wide(void **state) {
 	assert_box_equal(&after, 0, 0, 0, 0);
 }
 
+void arrange_wide__010_center_master(void **state) {
+	struct Box master, before, after;
+
+	struct Demand demand = { .usable_width = 16, .usable_height = 5, };
+	struct Tag tag = { .layout_cur = WIDE, .ratio_wide = 0.5, .center_master = true };
+
+	arrange_wide(&demand, &tag, 0, 1, 0, &before, &master, &after);
+
+	assert_box_equal(&before, 0, 0, 0, 0);
+	assert_box_equal(&master, 4, 0, 8, 5);
+	assert_box_equal(&after, 0, 0, 0, 0);
+}
+
 void arrange_wide__010_with_gaps(void **state) {
 	struct Box master, before, after;
 
 	struct Demand demand = { .view_count = 1, .usable_width = 13, .usable_height = 5, };
-	struct Tag tag = { .ratio_wide = 0.5, .fixed_master_wide = true, .smart_gaps = false,
+	struct Tag tag = { .ratio_wide = 0.5, .center_master = false, .smart_gaps = false,
 		.inner_gaps = 1, .outer_gaps = 1 };
 
-	struct Tag smart_tag = { .ratio_wide = 0.5, .fixed_master_wide = true, .smart_gaps = true,
+	struct Tag smart_tag = { .ratio_wide = 0.5, .center_master = false, .smart_gaps = true,
 		.inner_gaps = 1, .outer_gaps = 1 };
 
 	arrange_wide(&demand, &tag, 0, 1, 0, &before, &master, &after);
 	assert_box_equal(&before, 0, 0, 0, 0);
-	assert_box_equal(&master, 3, 1, 6, 3);
+	assert_box_equal(&master, 1, 1, 11, 3);
 	assert_box_equal(&after, 0, 0, 0, 0);
 
 	arrange_wide(&demand, &smart_tag, 0, 1, 0, &before, &master, &after);
 	assert_box_equal(&before, 0, 0, 0, 0);
-	assert_box_equal(&master, 3, 0, 6, 5);
+	assert_box_equal(&master, 0, 0, 13, 5);
 	assert_box_equal(&after, 0, 0, 0, 0);
 }
 
-void arrange_wide__010_with_gaps_no_fixed_master_wide(void **state) {
+void arrange_wide__010_with_gaps_center_master(void **state) {
 	struct Box master, before, after;
 
 	struct Demand demand = { .view_count = 1, .usable_width = 13, .usable_height = 5, };
-	struct Tag tag = { .ratio_wide = 0.5, .fixed_master_wide = false, .smart_gaps = false,
+	struct Tag tag = { .ratio_wide = 0.5, .center_master = false, .smart_gaps = false,
 		.inner_gaps = 1, .outer_gaps = 1 };
 
-	struct Tag smart_tag = { .ratio_wide = 0.5, .fixed_master_wide = false, .smart_gaps = true,
+	struct Tag smart_tag = { .ratio_wide = 0.5, .center_master = false, .smart_gaps = true,
 		.inner_gaps = 1, .outer_gaps = 1 };
 
 	arrange_wide(&demand, &tag, 0, 1, 0, &before, &master, &after);
@@ -276,7 +276,7 @@ int main(void) {
 	const struct CMUnitTest tests[] = {
 		TEST(arrange_wide__000),
 		TEST(arrange_wide__010),
-		TEST(arrange_wide__010_no_fixed_master_wide),
+		TEST(arrange_wide__010_center_master),
 		TEST(arrange_wide__001),
 		TEST(arrange_wide__100),
 		TEST(arrange_wide__101),
@@ -284,7 +284,7 @@ int main(void) {
 		TEST(arrange_wide__110),
 		TEST(arrange_wide__111),
 		TEST(arrange_wide__010_with_gaps),
-		TEST(arrange_wide__010_with_gaps_no_fixed_master_wide),
+		TEST(arrange_wide__010_with_gaps_center_master),
 		TEST(arrange_wide__001_with_gaps),
 		TEST(arrange_wide__100_with_gaps),
 		TEST(arrange_wide__101_with_gaps),

--- a/tst/tst-arrange_mid.c
+++ b/tst/tst-arrange_mid.c
@@ -42,7 +42,20 @@ void arrange_wide__010(void **state) {
 	struct Box master, before, after;
 
 	struct Demand demand = { .usable_width = 13, .usable_height = 5, };
-	struct Tag tag = { .ratio_wide = 999 };
+	struct Tag tag = { .ratio_wide = 0.5, .fixed_master_wide = true };
+
+	arrange_wide(&demand, &tag, 0, 1, 0, &before, &master, &after);
+
+	assert_box_equal(&before, 0, 0, 0, 0);
+	assert_box_equal(&master, 3, 0, 6, 5);
+	assert_box_equal(&after, 0, 0, 0, 0);
+}
+
+void arrange_wide__010_no_fixed_master_wide(void **state) {
+	struct Box master, before, after;
+
+	struct Demand demand = { .usable_width = 13, .usable_height = 5, };
+	struct Tag tag = { .ratio_wide = 0.5, .fixed_master_wide = false };
 
 	arrange_wide(&demand, &tag, 0, 1, 0, &before, &master, &after);
 
@@ -55,10 +68,32 @@ void arrange_wide__010_with_gaps(void **state) {
 	struct Box master, before, after;
 
 	struct Demand demand = { .view_count = 1, .usable_width = 13, .usable_height = 5, };
-	struct Tag tag = { .ratio_wide = 999, .smart_gaps = false,
-		.inner_gaps = 1, .outer_gaps = 1, };
-	struct Tag smart_tag = { .ratio_wide = 999, .smart_gaps = true,
-		.inner_gaps = 1, .outer_gaps = 1, };
+	struct Tag tag = { .ratio_wide = 0.5, .fixed_master_wide = true, .smart_gaps = false,
+		.inner_gaps = 1, .outer_gaps = 1 };
+
+	struct Tag smart_tag = { .ratio_wide = 0.5, .fixed_master_wide = true, .smart_gaps = true,
+		.inner_gaps = 1, .outer_gaps = 1 };
+
+	arrange_wide(&demand, &tag, 0, 1, 0, &before, &master, &after);
+	assert_box_equal(&before, 0, 0, 0, 0);
+	assert_box_equal(&master, 3, 1, 6, 3);
+	assert_box_equal(&after, 0, 0, 0, 0);
+
+	arrange_wide(&demand, &smart_tag, 0, 1, 0, &before, &master, &after);
+	assert_box_equal(&before, 0, 0, 0, 0);
+	assert_box_equal(&master, 3, 0, 6, 5);
+	assert_box_equal(&after, 0, 0, 0, 0);
+}
+
+void arrange_wide__010_with_gaps_no_fixed_master_wide(void **state) {
+	struct Box master, before, after;
+
+	struct Demand demand = { .view_count = 1, .usable_width = 13, .usable_height = 5, };
+	struct Tag tag = { .ratio_wide = 0.5, .fixed_master_wide = false, .smart_gaps = false,
+		.inner_gaps = 1, .outer_gaps = 1 };
+
+	struct Tag smart_tag = { .ratio_wide = 0.5, .fixed_master_wide = false, .smart_gaps = true,
+		.inner_gaps = 1, .outer_gaps = 1 };
 
 	arrange_wide(&demand, &tag, 0, 1, 0, &before, &master, &after);
 	assert_box_equal(&before, 0, 0, 0, 0);
@@ -240,19 +275,16 @@ void arrange_wide__111_with_gaps(void **state) {
 int main(void) {
 	const struct CMUnitTest tests[] = {
 		TEST(arrange_wide__000),
-
 		TEST(arrange_wide__010),
+		TEST(arrange_wide__010_no_fixed_master_wide),
 		TEST(arrange_wide__001),
 		TEST(arrange_wide__100),
-
 		TEST(arrange_wide__101),
-
 		TEST(arrange_wide__011),
 		TEST(arrange_wide__110),
-
 		TEST(arrange_wide__111),
-
 		TEST(arrange_wide__010_with_gaps),
+		TEST(arrange_wide__010_with_gaps_no_fixed_master_wide),
 		TEST(arrange_wide__001_with_gaps),
 		TEST(arrange_wide__100_with_gaps),
 		TEST(arrange_wide__101_with_gaps),

--- a/tst/tst-arrange_mid.c
+++ b/tst/tst-arrange_mid.c
@@ -42,7 +42,7 @@ void arrange_wide__010(void **state) {
 	struct Box master, before, after;
 
 	struct Demand demand = { .usable_width = 13, .usable_height = 5, };
-	struct Tag tag = { .ratio_wide = 0.5, .center_master = false };
+	struct Tag tag = { .ratio_wide = 999, .center_master = false };
 
 	arrange_wide(&demand, &tag, 0, 1, 0, &before, &master, &after);
 
@@ -275,14 +275,19 @@ void arrange_wide__111_with_gaps(void **state) {
 int main(void) {
 	const struct CMUnitTest tests[] = {
 		TEST(arrange_wide__000),
+
 		TEST(arrange_wide__010),
 		TEST(arrange_wide__010_center_master),
 		TEST(arrange_wide__001),
 		TEST(arrange_wide__100),
+
 		TEST(arrange_wide__101),
+
 		TEST(arrange_wide__011),
 		TEST(arrange_wide__110),
+
 		TEST(arrange_wide__111),
+
 		TEST(arrange_wide__010_with_gaps),
 		TEST(arrange_wide__010_with_gaps_center_master),
 		TEST(arrange_wide__001_with_gaps),

--- a/tst/tst-cfg.c
+++ b/tst/tst-cfg.c
@@ -41,15 +41,15 @@ void valid_colour__valid(void **state) {
 	assert_true(valid_colour("0x09afAF12"));
 }
 
-void fixed_master_wide__default(void **state) {
-	assert_false(cfg->fixed_master_wide);
+void center_master__default(void **state) {
+	assert_false(cfg->center_master);
 }
 
-void fixed_master_wide__set(void **state) {
-	cfg_set_fixed_master_wide(true);
-	assert_true(cfg->fixed_master_wide);
-	cfg_set_fixed_master_wide(false);
-	assert_false(cfg->fixed_master_wide);
+void center_master__set(void **state) {
+	cfg_set_center_master(true);
+	assert_true(cfg->center_master);
+	cfg_set_center_master(false);
+	assert_false(cfg->center_master);
 }
 
 int main(void) {
@@ -58,8 +58,8 @@ int main(void) {
 		TEST(valid_colour__prefix),
 		TEST(valid_colour__alpha),
 		TEST(valid_colour__valid),
-		TEST(fixed_master_wide__default),
-		TEST(fixed_master_wide__set),
+		TEST(center_master__default),
+		TEST(center_master__set),
 	};
 
 	return RUN(tests);

--- a/tst/tst-cfg.c
+++ b/tst/tst-cfg.c
@@ -3,6 +3,8 @@
 #include <cmocka.h>
 #include <stdbool.h>
 
+#include "cfg.h"
+
 bool valid_colour(const char * const s);
 
 int before_all(void **state) {
@@ -39,12 +41,25 @@ void valid_colour__valid(void **state) {
 	assert_true(valid_colour("0x09afAF12"));
 }
 
+void fixed_master_wide__default(void **state) {
+	assert_false(cfg->fixed_master_wide);
+}
+
+void fixed_master_wide__set(void **state) {
+	cfg_set_fixed_master_wide(true);
+	assert_true(cfg->fixed_master_wide);
+	cfg_set_fixed_master_wide(false);
+	assert_false(cfg->fixed_master_wide);
+}
+
 int main(void) {
 	const struct CMUnitTest tests[] = {
 		TEST(valid_colour__len),
 		TEST(valid_colour__prefix),
 		TEST(valid_colour__alpha),
 		TEST(valid_colour__valid),
+		TEST(fixed_master_wide__default),
+		TEST(fixed_master_wide__set),
 	};
 
 	return RUN(tests);


### PR DESCRIPTION
Adds a new feature that allows the master view to remain "centered", even when no other views are present.

In this iteration, the new argument flag (boolean) for enabling this behavior is `center-master` . Omitting the arg will default the behavior to `false`.

`center-master` will work in all layouts, including monocle. When `center-master` is enabled:
  - in wide layout, the master view always occupies the same dimensions, regardless of how many other views are spawned. The view is centered horizontally, according to `ratio_wide`.
  - in left,right layouts, when only the master view is spawned, the view is centered horizontally with the **width** set according to `ratio_master`. Spawning additional views will layout the views normally (no longer centered master).
  - in top,bottom layouts, when only the master view is spawned, the view is centered vertically with **height** set according to `ratio_master`. The intention here was to enable this behavior for vertical screen users. Spawning additional views will layout the views normally (no longer centered master).
  - no effect in **monocle** layout.
  - in all layouts, outer_gaps are included in the width + height calculations
    (maybe they shouldn't be?).

----

### implementation notes

I've added some helper calculations + vars in arrange_wide. This was mostly for my own clarity and i think it reduces some of the repetitive condition blocks, e.g. where we have the same calculation for width or X position codified, just conditionally executed. (This could be taken much further, but I wanted to minimize diff overhead. Happy to make a separate PR for those changes or revert some of these shorthands). Overall, I did my best to avoid changing too much that wasn't related to this feature. 

---- 

### testing

a couple of test cases have been added for the arrange_wide and
arguments. All tests pass. This could probably use more test coverage, especially, `center-master` in  non-wide layouts.

AFAICT , there should be no effect to existing configurations. Omitting the new startup flag will default to false, and things should work as they previously did.

I've been using this on a couple of different systems for about a week.  

I have done any profiling. 

----

### Open questions / still to implement:

- help/documentation updates
- a command to toggle `center-master`
- determine what is the desired monocle behavior
- why, in 'wide' layouts, when there is no master view but there are before+after views does the ratio calculation use the complement of the `ratio_wide` (curious what the practical use case of this is)
- is it OK that this applies to non-wide layouts

